### PR TITLE
improve vim, tmux

### DIFF
--- a/.config/nvim/dein/dein.toml
+++ b/.config/nvim/dein/dein.toml
@@ -36,6 +36,9 @@ repo = 'ryanoasis/vim-devicons'
 repo = 'Yggdroot/indentLine'
 
 [[plugins]]
+repo = 'jiangmiao/auto-pairs'
+
+[[plugins]]
 repo = 'neoclide/coc.nvim'
 rev = 'release'
 merged = 0

--- a/.config/nvim/dein/dein_lazy.toml
+++ b/.config/nvim/dein/dein_lazy.toml
@@ -4,13 +4,6 @@ repo = 'Shougo/unite.vim'
 [[plugins]]
 repo = 'Shougo/neomru.vim'
 on_path = '.*'
-
-[[plugins]]
-repo = 'Shougo/neoyank.vim'
-on_path = '.*'
-
-[[plugins]]
-repo = 'jiangmiao/auto-pairs'
 on_i = 1
 
 [[plugins]]

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -295,7 +295,7 @@ nmap <leader>f  <Plug>(coc-format-selected)
 command! -nargs=0 Format :call CocAction('format')
 
 " yank list setting
-nnoremap <silent> hp  :<C-u>CocList -A --normal yank<cr>
+nnoremap <silent> yp :<C-u>CocList -A --normal yank<cr>
 """"""""""""""""""""""""""""""
 
 """"""""""""""""""""""""""""""

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -22,8 +22,8 @@ set-option -g status-left '#(memory) #(cpu-usage) #(storage)'
 
 # Contents right
 if-shell 'uname | grep -q Darwin' \
-    "set-option -g status-right '#[fg=white]#(wifi)#[default][%Y-%m-%d(%a) %H:%M]'" \
-    "set-option -g status-right '[%Y-%m-%d(%a) %H:%M]'"
+    "set-option -g status-right '#[fg=cyan]#S    #[fg=white]#(wifi)'" \
+    "set-option -g status-right '#[fg=cyan]#S'"
 
 # Reload statusbar
 set-option -g status-interval 5


### PR DESCRIPTION
I improve three bellow point.

- not load lazy vim-surround but at first, and remove not using plugin neo-yank
- show session name in tmux status bar
- change hot-key invoking coc-yank from hp to yp, because h is moving key and MUST NOT wait for next key