### PR TITLE
M1 Macのbrew対応とPATHの修正

### DIFF
--- a/.zsh/00_zshenv.zsh
+++ b/.zsh/00_zshenv.zsh
@@ -13,7 +13,7 @@ export SAVEHIST=1000000
 export LANG=en_US.UTF-8
 
 # PATH setting
-export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 # brew PATH setting
 export PATH="/usr/local/bin:/usr/local/sbin:$PATH"

--- a/.zsh/50_init_lang_mng.zsh
+++ b/.zsh/50_init_lang_mng.zsh
@@ -3,7 +3,7 @@
 ##############################
 
 # asdf setting
-if [ -f $HOME/.asdf/asdf.sh ]; then
+if [ -f $ZPLUG_REPOS/asdf-vm/asdf/asdf.sh ]; then
     source $ZPLUG_REPOS/asdf-vm/asdf/asdf.sh
     fpath=(${ASDF_DIR}/completions $fpath)
 fi

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 
 ### 1. Install requirements and setting zsh
 
+##### If you use M1 Mac
+I don't know why but one liner dosen't work.
+I will search the reason, but temporally, I suggest download a code and run it.
+
+```
+$ curl -L -O raw.githubusercontent.com/dondakeshimo/dotfiles/master/setup/entrypoint/mac_full.sh
+$ bash mac_full.sh
+```
+
 ##### If you use Mac
 ```
 $ bash -c "$(curl -L raw.githubusercontent.com/dondakeshimo/dotfiles/master/setup/entrypoint/mac_full.sh)"
@@ -17,7 +26,7 @@ $ bash -c "$(curl -L raw.githubusercontent.com/dondakeshimo/dotfiles/master/setu
 
 ### 2. Deploy dotfiles
 ```
-$ cd ~/src/github.com/dondakeshimo/dotfiles/setup
+$ cd ~/src/github.com/dondakeshimo/dotfiles/setup/deployer
 $ ./symlink.sh all
 ```
 
@@ -25,11 +34,13 @@ $ ./symlink.sh all
 
 - Use zsh
     - `chsh -s $(which zsh)`
+    - if you use Mac
+        - echo "<your zsh path>" >> /etc/shells
 - Install teminal color scheme
     - `setup/installer/solarized/`
 - Setup GitHub SSH connection
     - `ssh-keygen -t rsa`
-    - filename: ~/.ssh/id\_git\_rsa
+    - filename: /absolute/path/to/your/home/.ssh/id\_git\_rsa
 - Install nerd-fonts
     - https://github.com/ryanoasis/nerd-fonts
 - Install Docker


### PR DESCRIPTION
### 1. M1 Macのbrewのパスを直書きした

公式では
```
eval "$(/opt/homebrew/bin/brew shellenv)"
```

を `.zprofile` でやるように言われる。
何をしているかというと、シンプルにPATHに `opt/homebrew/bin` などを追加している(だけだと思う)
これがTMUXの環境に伝播せずにcommand not foundとなってしまっていたので、 `.zshrc` に直書きでPATHを指定して無理やり伝播させた。

### 2. asdfのPATHの修正

adsfはzpulgで管理するようにしているが、asdfがインストール済みかどうかを確認するPATHがgitでインストールしていた時のもののままになっていた。