### PR TITLE
dockerのlspのマウント先を指定

### DIFF
--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -2,3 +2,12 @@
 
 This directory contains some examples about coc.nvim + Language Server in Docker.
 Note that do not just copy and paste, I can't guarantee it to work.
+
+
+### Mount Volume Path
+
+LSP assumes that local process.
+So, if you want to build language server not in local and communicate it,
+you have to pretend to be in the server and communicate locally.
+Your volume mount destination in docker-compose.yml is the same as `pwd`,
+then you can be pretender.

--- a/languageserver/python/docker-compose.yml
+++ b/languageserver/python/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       context: .
       dockerfile: LanguageServer.dockerfile
     volumes:
-      - .:/app
+      - .:/path-to-your-repository
     ports:
       - 2087:2087
 

--- a/languageserver/ruby/docker-compose.yml
+++ b/languageserver/ruby/docker-compose.yml
@@ -10,6 +10,6 @@ services:
       context: .
       dockerfile: LanguageServer.dockerfile
     volumes:
-      - .:/app
+      - .:/path-to-your-repository
     ports:
       - 7658:7658


### PR DESCRIPTION
Resolve: #48 

> LSPはローカルプロセスを前提としています。
そのため、ローカルではない言語サーバを構築して通信したい場合は、サーバにいるふりをしてローカルに通信する必要があります。
docker-compose.ymlのボリュームマウント先が`pwd`と同じであれば、そのように装うことができます。