### PR TITLE
Install copilot chat

### DIFF
--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -179,6 +179,8 @@ require("lazy").setup({
       config = function(_, _)
         local cmp = require("cmp")
         local lspkind = require('lspkind')
+        vim.keymap.set("i", "<C-n>", cmp.complete, {})
+        vim.keymap.set("i", "<C-p>", cmp.complete, {})
         cmp.setup({
           snippet = {
             expand = function(args)

--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -212,6 +212,10 @@ require("lazy").setup({
               maxwidth = 80,
               ellipsis_char = '...',
               symbol_map = { Copilot = "" },
+              before = function(entry, vim_item)
+                vim_item.menu = entry.source.name
+                return vim_item
+              end
             })
           },
         })

--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -53,6 +53,18 @@ require("lazy").setup({
       },
       lazy = true,
       event = "BufRead",
+      ft = { "markdown" },
+      opts = {
+        on_attach = function(bufnr)
+          local ft = vim.fn.getbufvar(bufnr, "&filetype")
+          local ret = false
+          if ft == "markdown" then
+            ret = true
+          end
+
+          return ret
+        end
+      },
     },
     {
       "neovim/nvim-lspconfig",

--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -539,6 +539,35 @@ require("lazy").setup({
         vim.cmd.colorscheme 'solarized'
       end,
     },
+    {
+      "CopilotC-Nvim/CopilotChat.nvim",
+      branch = "main",
+      dependencies = {
+        { "zbirenbaum/copilot.lua" },
+        { "nvim-lua/plenary.nvim" },
+      },
+      build = "make tiktoken",
+      opts = {
+        window = {
+          layout = 'float',
+          width = 0.8,            -- fractional width of parent, or absolute width in columns when > 1
+          height = 0.8,           -- fractional height of parent, or absolute height in rows when > 1
+          relative = 'editor',    -- 'editor', 'win', 'cursor', 'mouse'
+          border = 'single',      -- 'none', single', 'double', 'rounded', 'solid', 'shadow'
+          title = 'Copilot Chat', -- title of chat window
+          zindex = 1,             -- determines if window is on top or below other floating windows
+        },
+        chat_autocomplete = false,
+      },
+      config = function(_, opts)
+        require("CopilotChat").setup(opts)
+        vim.keymap.set({ "n", "v" }, "<leader>cp", function()
+          local actions = require("CopilotChat.actions")
+          require("CopilotChat.integrations.telescope").pick(actions.prompt_actions())
+        end, {})
+        vim.keymap.set("n", "<leader>ct", "<cmd>CopilotChatToggle<CR>", {})
+      end,
+    },
   },
   install = { colorscheme = { "solarized" } },
   checker = { enabled = true },

--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -94,11 +94,23 @@ require("lazy").setup({
         require("mason-lspconfig").setup_handlers({
           function(server_name)
             require("lspconfig")[server_name].setup({
-              offset_encoding = "utf-8",
               capabilities = require('cmp_nvim_lsp').default_capabilities(
                 vim.lsp.protocol.make_client_capabilities()
               ),
             })
+            if server_name == "terraformls" then
+              require("lspconfig")[server_name].setup({
+                offset_encoding = "utf-8",
+              })
+            end
+            if server_name == "vacuum" then
+              vim.filetype.add {
+                pattern = {
+                  ['openapi.*%.ya?ml'] = 'yaml.openapi',
+                  ['openapi.*%.json'] = 'json.openapi',
+                },
+              }
+            end
           end,
         })
       end,
@@ -140,8 +152,9 @@ require("lazy").setup({
         lightbulb = { enable = false },
         rename = {
           auto_save = true,
+          project_max_witdh = 100,
           keys = {
-            quit = "<Esc>"
+            quit = "<C-c>"
           },
         },
       },

--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -82,7 +82,7 @@ require("lazy").setup({
             local builtin = require("telescope.builtin")
             vim.keymap.set("n", "gd", vim.lsp.buf.definition, { buffer = true })
             vim.keymap.set("n", "K", "<cmd>Lspsaga hover_doc<CR>", { buffer = true })
-            vim.keymap.set("n", "gi", builtin.lsp_references, { buffer = true })
+            vim.keymap.set("n", "gi", builtin.lsp_implementations, { buffer = true })
             vim.keymap.set("n", "gn", "<cmd>Lspsaga rename<CR>", { buffer = true })
             vim.keymap.set("n", "ga", "<cmd>Lspsaga code_action<CR>", { buffer = true })
             vim.keymap.set("n", "gr", builtin.lsp_references, { buffer = true })

--- a/.zsh/50_init_lang_mng.zsh
+++ b/.zsh/50_init_lang_mng.zsh
@@ -37,3 +37,6 @@ export POETRY_VIRTUALENVS_IN_PROJECT=true
 . "$HOME/.atuin/bin/env"
 
 eval "$(atuin init zsh)"
+
+# flutter with asdf setting
+export PATH="$(asdf where flutter)/bin":"$PATH"


### PR DESCRIPTION
This pull request includes several changes to the Neovim configuration and a small update to the Zsh initialization script. The most important changes include adding file type-specific settings, modifying key mappings, and configuring new plugins.

### Neovim configuration changes:

* Added file type-specific settings for Markdown files in the `lazy` setup. (`.config/nvim/lua/plugin.lua`)
* Changed the key mapping for `gi` to use `builtin.lsp_implementations` instead of `builtin.lsp_references`. (`.config/nvim/lua/plugin.lua`)
* Added specific configurations for `terraformls` and custom file types for `vacuum` in the LSP setup handlers. (`.config/nvim/lua/plugin.lua`)
* Modified the key mapping for quitting the rename action to `<C-c>` and added a new configuration option `project_max_width`. (`.config/nvim/lua/plugin.lua`)
* Added key mappings for triggering `cmp.complete` in insert mode and configured the `before` function for customizing completion items. (`.config/nvim/lua/plugin.lua`) [[1]](diffhunk://#diff-26d2ff25d29af51f9246987c463294d6c371a3e03a06b7d8eebcc0148554899eR182-R183) [[2]](diffhunk://#diff-26d2ff25d29af51f9246987c463294d6c371a3e03a06b7d8eebcc0148554899eR215-R218)
* Introduced a new plugin `CopilotChat.nvim` with specific configuration settings and key mappings. (`.config/nvim/lua/plugin.lua`)

### Zsh initialization script changes:

* Added the Flutter SDK path to the `PATH` environment variable using `asdf`. (`.zsh/50_init_lang_mng.zsh`)