### PR TITLE
install vim-easy-align

### DIFF
--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -510,6 +510,15 @@ require("lazy").setup({
       end,
     },
     {
+      "junegunn/vim-easy-align",
+      lazy = true,
+      event = "InsertEnter",
+      config = function()
+        vim.keymap.set("x", "<leader>a", "<Plug>(EasyAlign)", { silent = true, noremap = true })
+        vim.keymap.set("n", "<leader>a", "<Plug>(EasyAlign)", { silent = true, noremap = true })
+      end,
+    },
+    {
       "zbirenbaum/copilot.lua",
       cmd = "Copilot",
       event = "InsertEnter",


### PR DESCRIPTION
This pull request includes a new plugin addition to the Neovim configuration file to enhance text alignment functionality.

Plugin addition:

* [`.config/nvim/lua/plugin.lua`](diffhunk://#diff-26d2ff25d29af51f9246987c463294d6c371a3e03a06b7d8eebcc0148554899eR512-R520): Added the `junegunn/vim-easy-align` plugin with lazy loading on the `InsertEnter` event. Configured key mappings for normal and visual modes to use the EasyAlign feature.