### PR TITLE
Update 2026 06 19

### DIFF
--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -63,7 +63,7 @@
                 "to_if_held_down": [
                   {
                     "mouse_key": {
-                      "x": -8000
+                      "x": -4000
                     }
                   }
                 ],
@@ -92,7 +92,7 @@
                 "to_if_held_down": [
                   {
                     "mouse_key": {
-                      "y": -8000
+                      "y": -4000
                     }
                   }
                 ],
@@ -121,7 +121,7 @@
                 "to_if_held_down": [
                   {
                     "mouse_key": {
-                      "x": 8000
+                      "x": 4000
                     }
                   }
                 ],
@@ -150,7 +150,7 @@
                 "to_if_held_down": [
                   {
                     "mouse_key": {
-                      "y": 8000
+                      "y": 4000
                     }
                   }
                 ],

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -8,4 +8,5 @@
 require("bootstrap-lazy")
 require("option")
 require("keymap")
+require("autocmd")
 require("plugin") -- confirm that mapleader is set before invoke plugins

--- a/.config/nvim/lua/autocmd.lua
+++ b/.config/nvim/lua/autocmd.lua
@@ -1,0 +1,6 @@
+vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+  pattern = "*.avsc",
+  callback = function()
+    vim.bo.filetype = "json"
+  end,
+})

--- a/.config/nvim/lua/autocmd.lua
+++ b/.config/nvim/lua/autocmd.lua
@@ -4,3 +4,17 @@ vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
     vim.bo.filetype = "json"
   end,
 })
+
+-- detect files changed outside of nvim (e.g. by Claude Code) and reload the buffer.
+-- autoread alone does not reload until something triggers a filesystem check,
+-- so call :checktime on idle and focus events.
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold", "CursorHoldI", "TermClose", "TermLeave" }, {
+  pattern = "*",
+  callback = function()
+    -- skip command-line window and unnamed/special buffers
+    if vim.fn.mode() == "c" or vim.bo.buftype ~= "" then
+      return
+    end
+    vim.cmd("checktime")
+  end,
+})

--- a/.config/nvim/lua/option.lua
+++ b/.config/nvim/lua/option.lua
@@ -46,5 +46,8 @@ vim.opt.clipboard = "unnamed"
 -- updatetime
 vim.opt.updatetime = 100
 
+-- reload buffer when the file is changed outside of nvim (e.g. by Claude Code)
+vim.opt.autoread = true
+
 -- statusline
 vim.opt.laststatus = 3

--- a/.config/nvim/lua/plugin.lua
+++ b/.config/nvim/lua/plugin.lua
@@ -9,13 +9,11 @@ require("lazy").setup({
   spec = {
     {
       "nvim-treesitter/nvim-treesitter",
+      branch = "main",
       build = ":TSUpdate",
-      lazy = true,
-      event = "BufRead",
-      main = "nvim-treesitter.configs",
-      opts = {
-        highlight = { enable = true },
-        ensure_installed = {
+      lazy = false,
+      config = function()
+        local ensure_installed = {
           "bash",
           "c",
           "comment",
@@ -44,8 +42,34 @@ require("lazy").setup({
           "vimdoc",
           "xml",
           "yaml",
-        },
-      },
+        }
+
+        local nts = require("nvim-treesitter")
+        local installed_set = {}
+        for _, name in ipairs(nts.get_installed("parsers")) do
+          installed_set[name] = true
+        end
+        local to_install = {}
+        for _, name in ipairs(ensure_installed) do
+          if not installed_set[name] then
+            table.insert(to_install, name)
+          end
+        end
+        if #to_install > 0 then
+          nts.install(to_install)
+        end
+
+        vim.api.nvim_create_autocmd("FileType", {
+          callback = function(args)
+            local ft = vim.bo[args.buf].filetype
+            local lang = vim.treesitter.language.get_lang(ft) or ft
+            if lang and vim.treesitter.language.add(lang) then
+              vim.treesitter.start(args.buf, lang)
+              vim.bo[args.buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+            end
+          end,
+        })
+      end,
     },
     {
       "nvim-treesitter/nvim-treesitter-context",
@@ -108,6 +132,26 @@ require("lazy").setup({
             vim.lsp.protocol.make_client_capabilities()
           ),
           offset_encoding = "utf-8",
+        })
+        -- golangci-lint-langserver: プロジェクトに ./bin/custom-gcl があれば優先、
+        -- なければ global の golangci-lint を使う.
+        vim.lsp.config('golangci_lint_ls', {
+          capabilities = require('cmp_nvim_lsp').default_capabilities(
+            vim.lsp.protocol.make_client_capabilities()
+          ),
+          before_init = function(initialize_params, config)
+            local root = config.root_dir or vim.fn.getcwd()
+            local custom_gcl = root .. '/bin/custom-gcl'
+            if vim.fn.executable(custom_gcl) ~= 1 then
+              return -- bin が無ければ default (golangci-lint) のまま.
+            end
+            -- nvim-lspconfig の default command (v2 用 flags 付き) を維持し、
+            -- 先頭の binary だけを custom-gcl に差し替える.
+            local opts = initialize_params.initializationOptions
+            if opts and type(opts.command) == 'table' and opts.command[1] then
+              opts.command[1] = custom_gcl
+            end
+          end,
         })
         -- vacuum 用の設定
         vim.filetype.add {
@@ -357,9 +401,14 @@ require("lazy").setup({
       },
     },
     {
+      'nvim-telescope/telescope-fzf-native.nvim',
+      build = 'make',
+    },
+    {
       "nvim-telescope/telescope.nvim",
       dependencies = {
         "nvim-lua/plenary.nvim",
+        'nvim-telescope/telescope-fzf-native.nvim',
       },
       opts = {
         defaults = {
@@ -367,13 +416,52 @@ require("lazy").setup({
             prompt_position = "top",
           },
           sorting_strategy = "ascending",
+          extensions = {
+            fzf = {
+              fuzzy = true,
+              override_generic_sorter = true,
+              override_file_sorter = true,
+              case_mode = "smart_case",
+            }
+          }
         },
       },
       config = function(_, opts)
         require("telescope").setup(opts)
+        require('telescope').load_extension('fzf')
+
         local builtin = require("telescope.builtin")
+
+        -- https://blog.atusy.net/2024/08/02/telescope-grep-refiement/
+        local function filename_sorter()
+          local sorter = require("telescope.config").values.generic_sorter()
+          local score = sorter.scoring_function
+          sorter.scoring_function = function(self, prompt, _, entry)
+            return score(self, prompt, entry.filename, entry)
+          end
+          return sorter
+        end
+
+        vim.keymap.set("n", "<leader>fg", function()
+          builtin.live_grep({
+            attach_mappings = function(prompt_bufnr, map)
+              map("i", "<C-G><C-G>", function()
+                require("telescope.actions").send_to_qflist(prompt_bufnr)
+                builtin.quickfix({
+                  sorter = filename_sorter(),
+                })
+              end)
+              return true
+            end,
+          })
+        end, {})
+        vim.keymap.set("n", "<leader>fq", function()
+          builtin.quickfix({
+            sorter = filename_sorter(),
+          })
+        end, {})
+
         vim.keymap.set("n", "<leader>fp", builtin.git_files, {})
-        vim.keymap.set("n", "<leader>fg", builtin.live_grep, {})
         vim.keymap.set("n", "<leader>fb", builtin.buffers, {})
         vim.keymap.set("n", "<leader>fh", builtin.help_tags, {})
         vim.keymap.set("n", "<leader>fr", builtin.resume, {})
@@ -542,7 +630,7 @@ require("lazy").setup({
           markdown = true,
           gitcommit = true,
         },
-        copilot_model = 'gpt-4o-copilot',
+        -- copilot_model = 'claude-sonnet-4', https://github.com/github/copilot.vim/issues/77#issuecomment-2848712690
       },
     },
     {
@@ -564,108 +652,12 @@ require("lazy").setup({
       end,
     },
     {
-      "olimorris/codecompanion.nvim",
-      dependencies = {
-        "nvim-lua/plenary.nvim",
-        "nvim-treesitter/nvim-treesitter",
-        "j-hui/fidget.nvim",
-        { 'echasnovski/mini.diff', opts = {} },
-      },
-      config = function()
-        local default_model = "anthropic/claude-sonnet-4"
-
-        require("fidget-spinner"):init()
-
-        require("codecompanion").setup({
-          strategies = {
-            chat = {
-              adapter = "openrouter",
-              roles = {
-                llm = function(adapter)
-                  return "  CodeCompanion (" .. adapter.formatted_name .. ")"
-                end,
-                user = "  Me",
-              },
-              tools = {
-                ["mcp"] = {
-                  callback = function()
-                    return require("mcphub.extensions.codecompanion")
-                  end,
-                  description = "Call tools and resources from the MCP Servers"
-                }
-              },
-            },
-            inline = {
-              adapter = "openrouter",
-            },
-          },
-          adapters = {
-            openrouter = function()
-              return require("codecompanion.adapters").extend("openai_compatible", {
-                env = {
-                  url = "https://openrouter.ai/api",
-                  api_key = "OPENROUTER_API_KEY",
-                  chat_url = "/v1/chat/completions",
-                },
-                schema = {
-                  model = {
-                    default = default_model,
-                  },
-                },
-              })
-            end,
-          },
-          opts = {
-            language = "Japanese",
-          },
-          display = {
-            chat = {
-              show_header_separator = true,
-              window = {
-                position = "right",
-              },
-            },
-            diff = {
-              enabled = true,
-              layout = "horizontal",
-              provider = "mini_diff",
-            },
-          },
-        })
-
-        vim.keymap.set({ "n", "v" }, "<leader>ck", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
-        vim.keymap.set({ "n", "v" }, "<leader>cc", "<cmd>CodeCompanionChat Toggle<cr>", { noremap = true, silent = true })
-        vim.keymap.set("v", "<leader>ca", "<cmd>CodeCompanionChat Add<cr>", { noremap = true, silent = true })
-        -- Expand 'cc' into 'CodeCompanion' in the command line
-        vim.cmd([[cab cc CodeCompanion]])
-      end,
-    },
-    {
       "MeanderingProgrammer/render-markdown.nvim",
       dependencies = { "nvim-treesitter/nvim-treesitter", "echasnovski/mini.icons" },
-      ft = { "markdown", "markdown.mdx", "Avante", "codecompanion" },
+      ft = { "markdown", "markdown.mdx", "Avante" },
       opts = {
-        file_types = { "markdown", "Avante", "codecompanion" },
+        file_types = { "markdown", "Avante" },
       }
-    },
-    {
-      "ravitemer/mcphub.nvim",
-      dependencies = {
-        "nvim-lua/plenary.nvim",
-      },
-      cmd = "MCPHub",
-      build = "npm install -g mcp-hub@latest",
-      config = function()
-        require("mcphub").setup({
-          extensions = {
-            codecompanion = {
-              show_result_in_chat = true,
-              make_vars = true,
-              make_slash_commands = true,
-            }
-          }
-        })
-      end,
     },
     {
       "mfussenegger/nvim-dap",

--- a/.gitconfig
+++ b/.gitconfig
@@ -8,6 +8,7 @@
 
 [core]
 	excludesfile = ~/.gitignore_global
+	quotepath = false
 
 [color]
 	ui = auto
@@ -48,6 +49,7 @@
 
 [init]
 	templatedir = ~/.git-templates/git-secrets
+	defaultBranch = main
 
 [pull]
 	rebase = false

--- a/.ssh/config
+++ b/.ssh/config
@@ -1,3 +1,10 @@
+Host github github.com
+    Hostname github.com
+    IdentityFile ~/.ssh/id_git_rsa
+    User git
+    LogLevel QUIET
+    UserKnownHostsFile ~/.ssh/known_hosts
+
 Host *
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null
@@ -5,9 +12,3 @@ Host *
     ServerAliveCountMax 30
     AddKeysToAgent yes
     IdentitiesOnly yes
-
-Host github github.com
-    Hostname github.com
-    IdentityFile ~/.ssh/id_git_rsa
-    User git
-    LogLevel QUIET

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -93,6 +93,13 @@ set-option -ga terminal-overrides ',xterm-256color:Tc'
 # バッファを10000行に設定(デフォルト2000行)
 set-option -g history-limit 10000
 
+# Claude Code 向け設定
+# https://code.claude.com/docs/en/terminal-config.md#configure-tmux
+# Shift+Enter での改行入力、デスクトップ通知・進捗表示の透過に必要
+set-option -g allow-passthrough on
+set-option -s extended-keys on
+set-option -ga terminal-features 'xterm*:extkeys'
+
 
 ##############################
 ## KEY BINDING

--- a/.zsh/00_zshenv.zsh
+++ b/.zsh/00_zshenv.zsh
@@ -19,6 +19,7 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 export MYBIN="$HOME/bin"
 export PATH="$MYBIN:$PATH"
 export PATH="$ZPLUG_BIN:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 
 # src dir setting
 export SRCDIR=$HOME/src

--- a/.zsh/40_aliases.zsh
+++ b/.zsh/40_aliases.zsh
@@ -25,5 +25,5 @@ alias lla='ls -la'
 alias airport='/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport'
 
 # fzf util
-alias treecd='tree --charset=o -f | fzf | tr -d '"'"'\||`|-'"'"' | xargs echo | cd'
-alias gcd='ghq list --full-path | fzf | xargs echo | cd'
+alias treecd='cd $(tree --charset=o -f | fzf | tr -d '"'"'\||`|-'"'"')'
+alias gcd='cd $(ghq list --full-path | fzf)'

--- a/.zsh/50_init_lang_mng.zsh
+++ b/.zsh/50_init_lang_mng.zsh
@@ -30,3 +30,7 @@ export POETRY_VIRTUALENVS_IN_PROJECT=true
 # flutter with asdf setting
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 export PATH="$(asdf where flutter)/bin":"$PATH"
+export PATH="$PATH":"$HOME/.pub-cache/bin"
+
+# mise
+eval "$(mise activate zsh)"

--- a/.zsh/zplug.zsh
+++ b/.zsh/zplug.zsh
@@ -17,7 +17,6 @@ zplug 'zsh-users/zsh-completions'
 zplug 'zsh-users/zsh-syntax-highlighting', defer:2
 zplug "zsh-users/zsh-history-substring-search"
 zplug 'mollifier/anyframe'
-zplug "b4b4r07/enhancd", use:init.sh
 zplug "docker/cli", use:"contrib/completion/zsh/_docker", lazy:true
 
 if ! zplug check --verbose; then


### PR DESCRIPTION
This pull request makes several improvements and adjustments to your development environment setup, focusing on Neovim configuration, terminal and shell usability, mouse key speed, and SSH/Git settings. The most significant changes are grouped below by theme.

**Neovim Enhancements:**

* Added an `autocmd.lua` module and updated `init.lua` to improve filetype detection (e.g., `.avsc` as JSON) and enable automatic reloading of buffers when files change outside of Neovim. Also enabled `autoread` in options. [[1]](diffhunk://#diff-9ccf8f688d26f5ff153fa72d95877297bad613b21f5ae298d68e7abb8967d807R1-R20) [[2]](diffhunk://#diff-c1cb3977ee06dc59242fde28a9468e9ea8a1f82992f15bb8d3ae077d5d1fec8eR49-R51) [[3]](diffhunk://#diff-63d8bcd646a1e22231af249afbeadca374e8ae4f2757d0d9c56dae22b74ae294R11)
* Refactored Treesitter plugin setup: made it always load (not lazy), ensured required parsers are installed, and dynamically started Treesitter per filetype via autocmd. [[1]](diffhunk://#diff-26d2ff25d29af51f9246987c463294d6c371a3e03a06b7d8eebcc0148554899eR12-R16) [[2]](diffhunk://#diff-26d2ff25d29af51f9246987c463294d6c371a3e03a06b7d8eebcc0148554899eL47-R72)
* Enhanced Telescope fuzzy finding by adding the `telescope-fzf-native.nvim` extension, configuring advanced sorting, and customizing keymaps for live grep and quickfix lists.
* Added custom configuration for `golangci-lint-langserver` to prefer a project-local binary if available.
* Removed `codecompanion.nvim` and `mcphub.nvim` plugins and their related filetype associations, simplifying the plugin set.

**Terminal and Shell Usability:**

* Updated `.tmux.conf` to improve compatibility with Claude Code, enabling passthrough and extended keys for better Shift+Enter handling and notifications.
* Improved shell `PATH` handling in `.zsh/00_zshenv.zsh` and `.zsh/50_init_lang_mng.zsh` to prioritize user and language manager binaries, and added initialization for `mise`. [[1]](diffhunk://#diff-ae100cb78cf486bbca28a7927e6625d6bc868fc470a2e371a3c37c1fdba3d6edR22) [[2]](diffhunk://#diff-eebf5e2b74d0ef2122dc80b8a6d9a586cb560c862b05999c6aecc13a8001c3c8R33-R36)
* Refined `treecd` and `gcd` aliases to use command substitution for direct directory changes.
* Removed the `enhancd` plugin from `zplug.zsh` to streamline shell plugin management.

**Mouse Key Speed Adjustment (Karabiner):**

* Reduced mouse key movement speed in all directions by halving the `x` and `y` values from 8000 to 4000, making mouse movement via keyboard more manageable. (.config/karabiner/karabiner.json) [[1]](diffhunk://#diff-766c006d1b0cc05fe9eced237ea6fc86200e32f7ab6f39e296955e22865c5315L66-R66) [[2]](diffhunk://#diff-766c006d1b0cc05fe9eced237ea6fc86200e32f7ab6f39e296955e22865c5315L95-R95) [[3]](diffhunk://#diff-766c006d1b0cc05fe9eced237ea6fc86200e32f7ab6f39e296955e22865c5315L124-R124) [[4]](diffhunk://#diff-766c006d1b0cc05fe9eced237ea6fc86200e32f7ab6f39e296955e22865c5315L153-R153)

**SSH and Git Configuration:**

* Moved the GitHub host block to the top of `.ssh/config` for precedence and clarity.
* Updated `.gitconfig` to disable path quoting and set the default branch to `main` for new repositories. [[1]](diffhunk://#diff-3cbe50069f7ffe4d55b4d1fe7a72fb79e9c9545af55d8326a728b98f00481bf2R11) [[2]](diffhunk://#diff-3cbe50069f7ffe4d55b4d1fe7a72fb79e9c9545af55d8326a728b98f00481bf2R52)

These changes collectively enhance your workflow efficiency, code navigation, and editor responsiveness, while also simplifying and clarifying your environment setup.